### PR TITLE
Fix URL not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "lint-staged": "^8.1.0",
     "parcel-bundler": "^1.11.0",
     "prettier": "^1.15.3",
-    "serverless": "^1.35.1"
+    "serverless": "^1.35.1",
+    "serverless-dotenv-plugin": "^2.0.1"
   },
   "config": {
     "commitizen": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,5 +1,8 @@
 service: sjofartstidningen-services
 
+plugins:
+  - serverless-dotenv-plugin
+
 provider:
   name: aws
   runtime: nodejs8.10
@@ -24,25 +27,24 @@ package:
     - '!static/**'
     - '**/*.map'
 
-environment:
-  NODE_ENV: ${opt:stage, self:custom.defaultStage}
-  MAILCHIMP_DC: ${env:MAILCHIMP_DC}
-  MAILCHIMP_API_KEY: ${env:MAILCHIMP_API_KEY}
-  MAILCHIMP_LIST_ID: ${env:MAILCHIMP_LIST_ID}
-  GOOGLE_CLIENT_EMAIL: ${env:GOOGLE_CLIENT_EMAIL}
-  GOOGLE_PRIVATE_KEY: ${env:GOOGLE_PRIVATE_KEY}
-  GOOGLE_VIEW_ID: ${env:GOOGLE_VIEW_ID}
-  SENDGRID_API_KEY: ${env:SENDGRID_API_KEY}
-
 functions:
   analytics:
     description: 'A weekly digest of useful analytics from Google and Mailchimp'
     handler: build/analytics.send
+    timeout: 10
     environment:
       VERSION: '1.0.0'
+      NODE_ENV: ${opt:stage, self:custom.defaultStage}
+      MAILCHIMP_DC: ${env:MAILCHIMP_DC}
+      MAILCHIMP_API_KEY: ${env:MAILCHIMP_API_KEY}
+      MAILCHIMP_LIST_ID: ${env:MAILCHIMP_LIST_ID}
+      GOOGLE_CLIENT_EMAIL: ${env:GOOGLE_CLIENT_EMAIL}
+      GOOGLE_PRIVATE_KEY: ${env:GOOGLE_PRIVATE_KEY}
+      GOOGLE_VIEW_ID: ${env:GOOGLE_VIEW_ID}
+      SENDGRID_API_KEY: ${env:SENDGRID_API_KEY}
     events:
       - schedule:
-        name: weekly
-        description: 'Every monday at 6 am (UTC)'
-        rate: cron(0 6 * * MON *)
-        enabled: true
+          name: weekly
+          description: 'Every monday at 6 am (UTC)'
+          rate: cron(0 6 ? * MON *)
+          enabled: true

--- a/utils/__tests__/__snapshots__/handlebar-helpers.js.snap
+++ b/utils/__tests__/__snapshots__/handlebar-helpers.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`handlebarHelpers.capString should cut a string and append ellipsis based on length 1`] = `"The brown fox ju..."`;
+
+exports[`handlebarHelpers.capString should cut a string and append ellipsis based on length 2`] = `"..."`;

--- a/utils/__tests__/handlebar-helpers.js
+++ b/utils/__tests__/handlebar-helpers.js
@@ -1,0 +1,50 @@
+import * as helpers from '../handlebars-helpers';
+
+// percent, formatNumber, capString, urlPath, gt
+
+describe('handlebarHelpers.percent', () => {
+  it('should transform a float to percent', () => {
+    expect(helpers.percent(0.1)).toEqual('10.0%');
+    expect(helpers.percent(0.1234)).toEqual('12.3%');
+    expect(helpers.percent(-0.01)).toEqual('-1.0%');
+  });
+});
+
+describe('handlebarHelpers.formatNumber', () => {
+  it('should format a number', () => {
+    expect(helpers.formatNumber(1234)).toEqual('1,234');
+    expect(helpers.formatNumber(1)).toEqual('1');
+    expect(helpers.formatNumber(1000.5)).toEqual('1,000.5');
+  });
+});
+
+describe('handlebarHelpers.capString', () => {
+  it('should cut a string and append ellipsis based on length', () => {
+    expect(helpers.capString(100, 'The brown fox jumped')).toMatchSnapshot();
+    expect(helpers.capString(10, 'The brown fox jumped')).toMatchSnapshot();
+  });
+});
+
+describe('handlebarHelpers.urlPath', () => {
+  it('should extract only the path and serach parts of a url', () => {
+    expect(helpers.urlPath('https://test.com')).toEqual('/');
+    expect(helpers.urlPath('https://test.com/')).toEqual('/');
+    expect(helpers.urlPath('https://test.com/path-part')).toEqual('/path-part');
+    expect(helpers.urlPath('https://test.com/path-part?search=part')).toEqual(
+      '/path-part?search=part',
+    );
+  });
+});
+
+describe('handlebarHelpers.gt', () => {
+  it('should check if num 1 is greater than num 2', () => {
+    const opts = {
+      fn: jest.fn(() => 'num 1 is greater'),
+      inverse: jest.fn(() => 'num 2 is greater'),
+    };
+
+    expect(helpers.gt(3, 2, opts)).toEqual('num 1 is greater');
+    expect(helpers.gt(2, 3, opts)).toEqual('num 2 is greater');
+    expect(helpers.gt(2, 2, opts)).toEqual('num 2 is greater');
+  });
+});

--- a/utils/handlebars-helpers.js
+++ b/utils/handlebars-helpers.js
@@ -10,7 +10,7 @@ const capString = (maxWidth, string) => {
 
   let finalString = `${string.slice(0, -1)}...`;
 
-  while (getWidth(finalString) > maxWidth) {
+  while (getWidth(finalString) > maxWidth && finalString.length > 3) {
     finalString = `${finalString.replace('...', '').slice(0, -1)}...`;
   }
 

--- a/utils/handlebars-helpers.js
+++ b/utils/handlebars-helpers.js
@@ -1,3 +1,4 @@
+import { URL } from 'url';
 import { getWidth } from './string-pixel-width';
 
 const percent = num => `${(num * 100).toFixed(1)}%`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2608,9 +2608,14 @@ dot-prop@^4.1.0, dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv-expand@^4.2.0:
+dotenv-expand@^4.0.1, dotenv-expand@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-4.2.0.tgz#def1f1ca5d6059d24a766e587942c21106ce1275"
+
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+  integrity sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=
 
 dotenv@^5.0.0:
   version "5.0.1"
@@ -7723,6 +7728,15 @@ serve-static@1.13.2, serve-static@^1.12.4:
     escape-html "~1.0.3"
     parseurl "~1.3.2"
     send "0.16.2"
+
+serverless-dotenv-plugin@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/serverless-dotenv-plugin/-/serverless-dotenv-plugin-2.0.1.tgz#a2dbee0030c3bbd5801b37ca9266405ce5d9304b"
+  integrity sha512-qtahguv0X3UOeFdJ7C27CoRp9/6dqwTNTe+mZLPX5FDBQwhDOZzKtVIeW7bJLKWzz3JnAJfCOqpArWLpZduHBA==
+  dependencies:
+    chalk "^2.1.0"
+    dotenv "^4.0.0"
+    dotenv-expand "^4.0.1"
 
 serverless@^1.35.1:
   version "1.35.1"


### PR DESCRIPTION
This PR fixes an issue where the function was throwing because `"URL is not defined"`.
This is due to changes in how Node provides the URL global. In newer version of Node the `URL` is available globally. But in Node 8.10 (which Lambda runs on) `URL` must be required from the url-module:

```js
const { URL } = require('url');
import { URL } from 'url';
```

This PR also adds some tests to the handlebar helpers and fixes some regressions that popped up.